### PR TITLE
Fix Memory Leaks for 'ButtonStyleBuilder'

### DIFF
--- a/ButtonStyleKitSample/ButtonStyleKit/ButtonStyleBuilder.swift
+++ b/ButtonStyleKitSample/ButtonStyleKit/ButtonStyleBuilder.swift
@@ -17,7 +17,7 @@ private class Data<T> {
 
 open class ButtonStyleBuilder {
     // Basic
-    private var button = ButtonStyleKit()
+    private weak var button: ButtonStyleKit!
     private var state: ButtonStyleKit.ButtonState = .normal
     // Styles
     private var font = Data<UIFont>()
@@ -368,6 +368,7 @@ open class ButtonStyleBuilder {
     }
     
     public func apply() {
+        guard let button = button else { return }
         self.state = button.currentState
         build()
     }


### PR DESCRIPTION
##  Leaking Process
1.  When `setButton(_:)` method is called, it overwrites `button` variable.

https://github.com/keygx/ButtonStyleKit/blob/ff5c5325448ef7a2e9fc268ed99f1c17680a4fee/ButtonStyleKitSample/ButtonStyleKit/ButtonStyleBuilder.swift#L20

https://github.com/keygx/ButtonStyleKit/blob/ff5c5325448ef7a2e9fc268ed99f1c17680a4fee/ButtonStyleKitSample/ButtonStyleKit/ButtonStyleBuilder.swift#L51-L54

2. `button` 's sub-classes' references stay after they referred from this class.

https://github.com/keygx/ButtonStyleKit/blob/ff5c5325448ef7a2e9fc268ed99f1c17680a4fee/ButtonStyleKitSample/ButtonStyleKit/ButtonStyleBuilder.swift#L274

https://github.com/keygx/ButtonStyleKit/blob/ff5c5325448ef7a2e9fc268ed99f1c17680a4fee/ButtonStyleKitSample/ButtonStyleKit/ButtonStyleBuilder.swift#L278

3. `button` 's strong reference stays even after `deinit` of this class is called.

## How I confirmed it's fixed
- [Used this branch](https://github.com/skondo-quo/ButtonStyleKit/pull/1) to check if still leaking.

## Screenshots
### Before Fix
<img width="270" alt="2019-02-07 14 11 50" src="https://user-images.githubusercontent.com/44660597/52392627-16826600-2ae6-11e9-9b4a-0bf3f5e2a5cc.png">
<img width="1027" alt="2019-02-07 14 12 53" src="https://user-images.githubusercontent.com/44660597/52392632-1a15ed00-2ae6-11e9-817b-487ec5ff8d25.png">
<img width="1026" alt="2019-02-07 14 13 02" src="https://user-images.githubusercontent.com/44660597/52392639-20a46480-2ae6-11e9-8b9c-412b6d495574.png">
<img width="1027" alt="2019-02-07 14 13 13" src="https://user-images.githubusercontent.com/44660597/52392647-28640900-2ae6-11e9-8b1c-166dc45a86e0.png">

### After Fix
<img width="714" alt="2019-02-07 14 24 46" src="https://user-images.githubusercontent.com/44660597/52392653-30bc4400-2ae6-11e9-9dec-c278e8da87df.png">